### PR TITLE
[#33] Listen and parse bootp on loopback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+* Support for capturing the bootp packets on the local loopback
+  interface.
+  (Github #33, #35).
+
 * Enabled server sent events (SSE) endpoint returning periodic
   metrics reports.
   (Github #29, #31).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ serde_json = { version = "1.0.114", features = ["raw_value"] }
 actix-web-lab = "0.20.2"
 tokio-stream = "0.1.14"
 assert_json = "0.1.0"
+libc = "0.2.153"

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -358,9 +358,7 @@ impl Dispatcher {
                 CsvOutputType::File(csv_output) => {
                     let writer = WriterBuilder::new().has_headers(true).from_path(csv_output);
                     match writer {
-                        Ok(writer) => {
-                            self.enable_csv_reports(analyzer.clone(), writer)
-                        }
+                        Ok(writer) => self.enable_csv_reports(analyzer.clone(), writer),
                         Err(_) => {
                             return Err(DispatchError::CsvWriterError(
                                 writer.err().unwrap().to_string(),


### PR DESCRIPTION
The listener now distinguish between ethernet and loopback data link type. Based on that, it finds the correct offset of the DHCP payload. This enables capturing the traffic on local loopback interface.