### PR TITLE
[#45] Generating traffic capture files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+* Implemented saving packet capture files.
+  (Github #45, #46).
+
 ## Release v0.2.0 (Mar 13th, 2024)
 
 * Added new metrics `opcode_boot_requests_total`,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 endure-lib = { path = "endure-lib" }
 clap = { version = "4.4.18", features = ["derive"] }
 csv = "1.3.0"
-pcap = "1.2.0"
+pcap = { version = "1.2.0", features = ["capture-stream"] }
 serde = { version = "1.0.195", features = ["derive"] }
 thiserror = "1.0.40"
 simple_moving_average = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,5 @@ assert_cmd = "2.0.14"
 assert_json = "0.1.0"
 libc = "0.2.153"
 predicates = "3.1.0"
+tempdir = "0.3.7"
 

--- a/endure-lib/Cargo.toml
+++ b/endure-lib/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.77"
+chrono = "0.4.35"
 futures = "0.3.30"
 pcap = { version = "1.2.0", features = ["capture-stream"] }
 thiserror = "1.0.40"
@@ -15,3 +16,4 @@ tokio = { version = "1.36.0", features = ["full"] }
 
 [dev-dependencies]
 libc = "0.2.153"
+predicates = "3.1.0"

--- a/endure-lib/Cargo.toml
+++ b/endure-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endure-lib"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,7 +9,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.77"
 futures = "0.3.30"
-pcap = "1.2.0"
+pcap = { version = "1.2.0", features = ["capture-stream"] }
 thiserror = "1.0.40"
 tokio = { version = "1.36.0", features = ["full"] }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -130,7 +130,7 @@ impl Cli {
                     let filter = Filter::new().bootp_server_relay();
                     // Bind to the specified interfaces.
                     for interface_name in interface_names.iter() {
-                        let result = dispatcher.add_listener(interface_name.as_str(), &filter);
+                        let result = dispatcher.add_listener(interface_name.as_str(), filter);
                         if let Some(err) = result.err() {
                             eprintln!("{}", err.to_string());
                             exit(128);


### PR DESCRIPTION
Starting with some small refactoring of the listener to make them more asynchronous. The general goal, however, is to add an option to the listeners to dump the captured traffic into a file. It requires some new command line options so the user can specify a directory where the files are created or explicit file names.