### PR TITLE
[#50] Split the existing auditors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # ChangeLog
 
+* Implemented Dedicated `opcode` and `retransmission` auditors
+  for processing `pcap` files. They collect and display the
+  metrics from all packets in the `pcap`. Different auditors
+  are used in case of the live stream analysis and `pcap` files
+  with periodic metrics reports. These auditors collect the metrics
+  from the last 100 packets.
+ (Github #50, #51).
+
 * Enabled `pcap` file analysis with the `endure read` command.
+ (Github #37, #49).
 
 * Code refactoring required for collecting variable number of
   metrics depending on the selected profile. It introduces no

--- a/src/auditor/metric.rs
+++ b/src/auditor/metric.rs
@@ -18,14 +18,33 @@ pub const METRIC_OPCODE_BOOT_REPLIES_PERCENT: &str = "opcode_boot_replies_percen
 /// Percentage of the invalid `BOOTP` message opcodes in all messages.
 pub const METRIC_OPCODE_INVALID_PERCENT: &str = "opcode_invalid_percent";
 
-/// Percentage of the retransmissions.
+/// Percentage of the `BootRequest` messages in last 100 messages.
+pub const METRIC_OPCODE_BOOT_REQUESTS_PERCENT_100: &str = "opcode_boot_requests_percent_100";
+
+/// Percentage of the `BootReply` messages in last 100 messages.
+pub const METRIC_OPCODE_BOOT_REPLIES_PERCENT_100: &str = "opcode_boot_replies_percent_100";
+
+/// Percentage of the invalid `BOOTP` message opcodes in last 100 messages.
+pub const METRIC_OPCODE_INVALID_PERCENT_100: &str = "opcode_invalid_percent_100";
+
+/// Percentage of the retransmissions in all messages.
 pub const METRIC_RETRANSMIT_PERCENT: &str = "retransmit_percent";
 
-/// Average value of the `secs` field in retransmissions.
+/// Average value of the `secs` field in all retransmissions.
 pub const METRIC_RETRANSMIT_SECS_AVG: &str = "retransmit_secs_avg";
 
-/// Hardware address of the longest retrying client.
+/// Hardware address of the longest retrying client in all retransmissions.
 pub const METRIC_RETRANSMIT_LONGEST_TRYING_CLIENT: &str = "retransmit_longest_trying_client";
+
+/// Percentage of the retransmissions in last 100 messages.
+pub const METRIC_RETRANSMIT_PERCENT_100: &str = "retransmit_percent_100";
+
+/// Average value of the `secs` field in last 100 retransmissions.
+pub const METRIC_RETRANSMIT_SECS_AVG_100: &str = "retransmit_secs_avg_100";
+
+/// Hardware address of the longest retrying client in last 100 retransmissions.
+pub const METRIC_RETRANSMIT_LONGEST_TRYING_CLIENT_100: &str =
+    "retransmit_longest_trying_client_100";
 
 /// Timestamp of the last analyzed packet.
 pub const METRIC_PACKET_TIME_DATE_TIME: &str = "packet_time_date_time";

--- a/src/auditor/opcode.rs
+++ b/src/auditor/opcode.rs
@@ -10,14 +10,15 @@ use endure_macros::{AuditProfileCheck, FromMetricsStore};
 
 use super::{
     common::{AuditProfileCheck, DHCPv4PacketAuditor},
-    util::PercentSMA,
+    util::{PercentSMA, TotalCounter},
 };
 
-/// An auditor maintaining the statistics of the `BOOTP` message types.
+/// An auditor maintaining the total statistics of the `BOOTP` message
+/// types.
 ///
 /// It recognizes `BootRequest` and `BootReply` messages and maintains
-/// an average percentage of each message type in the received packets
-/// stream.
+/// a total number and the percentage of each message type in the received
+/// packets.
 ///
 /// # Metrics
 ///
@@ -30,47 +31,43 @@ use super::{
 /// The auditor also returns an average number of invalid messages
 /// (i.e., neither `BootRequest` nor `BootReply`).
 ///
+/// # Profiles
+///
+/// This auditor is used for analyzing capture files when the metrics are displayed
+/// at the end of the analysis.
+///
 #[derive(AuditProfileCheck, Clone, Debug, FromMetricsStore)]
 #[profiles(
     AuditProfile::LiveStreamFull,
     AuditProfile::PcapStreamFull,
     AuditProfile::PcapFinalFull
 )]
-pub struct OpCodeAuditor {
+pub struct OpCodeTotalAuditor {
     metrics_store: SharedMetricsStore,
-    requests_count: i64,
-    replies_count: i64,
-    invalid_count: i64,
-    opcodes: PercentSMA<3, 100>,
+    message_count: TotalCounter<3>,
 }
 
-impl Default for OpCodeAuditor {
+impl Default for OpCodeTotalAuditor {
     fn default() -> Self {
         Self {
             metrics_store: Default::default(),
-            requests_count: Default::default(),
-            replies_count: Default::default(),
-            invalid_count: Default::default(),
-            opcodes: PercentSMA::new(),
+            message_count: TotalCounter::new(),
         }
     }
 }
 
-impl DHCPv4PacketAuditor for OpCodeAuditor {
+impl DHCPv4PacketAuditor for OpCodeTotalAuditor {
     fn audit<'a>(&mut self, packet: &mut v4::PartiallyParsedPacket<'a>) {
         match packet.opcode() {
             Ok(opcode) => match opcode {
                 OpCode::BootRequest => {
-                    self.requests_count += 1;
-                    self.opcodes.increase(0usize);
+                    self.message_count.increase(0);
                 }
                 OpCode::BootReply => {
-                    self.replies_count += 1;
-                    self.opcodes.increase(1usize);
+                    self.message_count.increase(1);
                 }
                 OpCode::Invalid(_) => {
-                    self.invalid_count += 1;
-                    self.opcodes.increase(2usize);
+                    self.message_count.increase(2);
                 }
             },
             Err(_) => {}
@@ -81,37 +78,37 @@ impl DHCPv4PacketAuditor for OpCodeAuditor {
         let mut metrics_store = self.metrics_store.write().unwrap();
         metrics_store.set_metric_value(
             METRIC_OPCODE_BOOT_REQUESTS_COUNT,
-            MetricValue::Int64Value(self.requests_count),
+            MetricValue::Int64Value(self.message_count.counter(0)),
         );
 
         metrics_store.set_metric_value(
             METRIC_OPCODE_BOOT_REPLIES_COUNT,
-            MetricValue::Int64Value(self.replies_count),
+            MetricValue::Int64Value(self.message_count.counter(1)),
         );
 
         metrics_store.set_metric_value(
             METRIC_OPCODE_INVALID_COUNT,
-            MetricValue::Int64Value(self.invalid_count),
+            MetricValue::Int64Value(self.message_count.counter(2)),
         );
 
         metrics_store.set_metric_value(
             METRIC_OPCODE_BOOT_REQUESTS_PERCENT,
-            MetricValue::Float64Value(self.opcodes.average(0)),
+            MetricValue::Float64Value(self.message_count.percentage(0)),
         );
 
         metrics_store.set_metric_value(
             METRIC_OPCODE_BOOT_REPLIES_PERCENT,
-            MetricValue::Float64Value(self.opcodes.average(1)),
+            MetricValue::Float64Value(self.message_count.percentage(1)),
         );
 
         metrics_store.set_metric_value(
             METRIC_OPCODE_INVALID_PERCENT,
-            MetricValue::Float64Value(self.opcodes.average(2)),
+            MetricValue::Float64Value(self.message_count.percentage(2)),
         );
     }
 }
 
-impl InitMetrics for OpCodeAuditor {
+impl InitMetrics for OpCodeTotalAuditor {
     fn init_metrics(&mut self, metrics_store: &SharedMetricsStore) {
         self.metrics_store = metrics_store.clone();
         let mut metrics_store = self.metrics_store.write().unwrap();
@@ -135,19 +132,118 @@ impl InitMetrics for OpCodeAuditor {
 
         metrics_store.set_metric(Metric::new(
             METRIC_OPCODE_BOOT_REQUESTS_PERCENT,
-            "Percentage of the BootRequest messages.",
+            "Percentage of the BootRequest messages in all messages.",
             MetricValue::Float64Value(Default::default()),
         ));
 
         metrics_store.set_metric(Metric::new(
             METRIC_OPCODE_BOOT_REPLIES_PERCENT,
-            "Percentage of the BootReply messages.",
+            "Percentage of the BootReply messages in all messages.",
             MetricValue::Float64Value(Default::default()),
         ));
 
         metrics_store.set_metric(Metric::new(
             METRIC_OPCODE_INVALID_PERCENT,
-            "Percentage of the invalid messages.",
+            "Percentage of the invalid messages in all messages.",
+            MetricValue::Float64Value(Default::default()),
+        ));
+    }
+}
+
+/// An auditor maintaining the statistics of the `BOOTP` message types.
+///
+/// It recognizes `BootRequest` and `BootReply` messages and maintains
+/// an average percentage of each message type in the received packets
+/// stream.
+///
+/// # Metrics
+///
+/// Keeping track of the `BootRequest` and `BootReply` message types can
+/// be useful to detect situations when a DHCP server is unable to keep up
+/// with the traffic. Another extreme case is when the are only `BootRequest`
+/// messages and no `BootReply`. It indicates that the server is down
+/// or misconfigured.
+///
+/// The auditor also returns an average number of invalid messages
+/// (i.e., neither `BootRequest` nor `BootReply`).
+///
+/// # Profiles
+///
+/// This auditor is used for analyzing live packet streams or capture files
+/// when the metrics are periodically displayed during the analysis.
+///
+#[derive(AuditProfileCheck, Clone, Debug, FromMetricsStore)]
+#[profiles(AuditProfile::LiveStreamFull, AuditProfile::PcapStreamFull)]
+pub struct OpCodeStreamAuditor {
+    metrics_store: SharedMetricsStore,
+    opcodes: PercentSMA<3, 100>,
+}
+
+impl Default for OpCodeStreamAuditor {
+    fn default() -> Self {
+        Self {
+            metrics_store: Default::default(),
+            opcodes: PercentSMA::new(),
+        }
+    }
+}
+
+impl DHCPv4PacketAuditor for OpCodeStreamAuditor {
+    fn audit<'a>(&mut self, packet: &mut v4::PartiallyParsedPacket<'a>) {
+        match packet.opcode() {
+            Ok(opcode) => match opcode {
+                OpCode::BootRequest => {
+                    self.opcodes.increase(0usize);
+                }
+                OpCode::BootReply => {
+                    self.opcodes.increase(1usize);
+                }
+                OpCode::Invalid(_) => {
+                    self.opcodes.increase(2usize);
+                }
+            },
+            Err(_) => {}
+        };
+    }
+
+    fn collect_metrics(&mut self) {
+        let mut metrics_store = self.metrics_store.write().unwrap();
+        metrics_store.set_metric_value(
+            METRIC_OPCODE_BOOT_REQUESTS_PERCENT_100,
+            MetricValue::Float64Value(self.opcodes.average(0)),
+        );
+
+        metrics_store.set_metric_value(
+            METRIC_OPCODE_BOOT_REPLIES_PERCENT_100,
+            MetricValue::Float64Value(self.opcodes.average(1)),
+        );
+
+        metrics_store.set_metric_value(
+            METRIC_OPCODE_INVALID_PERCENT_100,
+            MetricValue::Float64Value(self.opcodes.average(2)),
+        );
+    }
+}
+
+impl InitMetrics for OpCodeStreamAuditor {
+    fn init_metrics(&mut self, metrics_store: &SharedMetricsStore) {
+        self.metrics_store = metrics_store.clone();
+        let mut metrics_store = self.metrics_store.write().unwrap();
+        metrics_store.set_metric(Metric::new(
+            METRIC_OPCODE_BOOT_REQUESTS_PERCENT_100,
+            "Percentage of the BootRequest messages in last 100 messages.",
+            MetricValue::Float64Value(Default::default()),
+        ));
+
+        metrics_store.set_metric(Metric::new(
+            METRIC_OPCODE_BOOT_REPLIES_PERCENT_100,
+            "Percentage of the BootReply messages in last 100 messages.",
+            MetricValue::Float64Value(Default::default()),
+        ));
+
+        metrics_store.set_metric(Metric::new(
+            METRIC_OPCODE_INVALID_PERCENT_100,
+            "Percentage of the invalid messages in last 100 messages.",
             MetricValue::Float64Value(Default::default()),
         ));
     }
@@ -161,25 +257,218 @@ mod tests {
         auditor::{
             common::{AuditProfile, AuditProfileCheck, DHCPv4PacketAuditor},
             metric::*,
-            opcode::OpCodeAuditor,
+            opcode::{OpCodeStreamAuditor, OpCodeTotalAuditor},
         },
         proto::{bootp::OPCODE_POS, dhcp::v4::ReceivedPacket, tests::common::TestBootpPacket},
     };
 
     #[test]
-    fn opcode_auditor_profiles() {
-        assert!(OpCodeAuditor::has_audit_profile(
+    fn opcode_total_auditor_profiles() {
+        assert!(OpCodeTotalAuditor::has_audit_profile(
             &AuditProfile::LiveStreamFull
         ));
-        assert!(OpCodeAuditor::has_audit_profile(
+        assert!(OpCodeTotalAuditor::has_audit_profile(
             &AuditProfile::PcapStreamFull
+        ));
+        assert!(OpCodeTotalAuditor::has_audit_profile(
+            &AuditProfile::PcapFinalFull
         ));
     }
 
     #[test]
-    fn opcode_auditor_audit() {
+    fn opcode_total_auditor_audit() {
         let metrics_store = MetricsStore::new().to_shared();
-        let mut auditor = OpCodeAuditor::from_metrics_store(&metrics_store);
+        let mut auditor = OpCodeTotalAuditor::from_metrics_store(&metrics_store);
+        let test_packet = TestBootpPacket::new();
+        let test_packet = test_packet.set(OPCODE_POS, &vec![1]);
+        let packet = &mut ReceivedPacket::new(test_packet.get()).into_parsable();
+        // Audit 5 request packets.
+        for _ in 0..5 {
+            auditor.audit(packet);
+        }
+        auditor.collect_metrics();
+        let metrics_store_ref = metrics_store.clone();
+
+        assert_eq!(
+            5,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<i64>(METRIC_OPCODE_BOOT_REQUESTS_COUNT)
+        );
+
+        assert_eq!(
+            0,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<i64>(METRIC_OPCODE_BOOT_REPLIES_COUNT)
+        );
+
+        assert_eq!(
+            0,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<i64>(METRIC_OPCODE_INVALID_COUNT)
+        );
+
+        assert_eq!(
+            100.0,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_BOOT_REQUESTS_PERCENT)
+        );
+
+        assert_eq!(
+            0.0,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_BOOT_REPLIES_PERCENT)
+        );
+
+        assert_eq!(
+            0.0,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_INVALID_PERCENT)
+        );
+
+        // Audit 3 reply packets. Now we have 8 packets audited (5 are requests and
+        // 3 are replies).
+        let test_packet = test_packet.set(OPCODE_POS, &vec![2]);
+        let packet = &mut ReceivedPacket::new(test_packet.get()).into_parsable();
+        for _ in 0..3 {
+            auditor.audit(packet);
+        }
+        auditor.collect_metrics();
+
+        assert_eq!(
+            5,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<i64>(METRIC_OPCODE_BOOT_REQUESTS_COUNT)
+        );
+
+        assert_eq!(
+            3,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<i64>(METRIC_OPCODE_BOOT_REPLIES_COUNT)
+        );
+
+        assert_eq!(
+            0,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<i64>(METRIC_OPCODE_INVALID_COUNT)
+        );
+
+        assert_eq!(
+            62.5,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_BOOT_REQUESTS_PERCENT)
+        );
+
+        assert_eq!(
+            37.5,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_BOOT_REPLIES_PERCENT)
+        );
+
+        assert_eq!(
+            0.0,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_INVALID_PERCENT)
+        );
+
+        // Finally, let's add some 2 invalid packets with opcode 3. We have a total of 10 packets
+        // (5 requests, 3 replies and 2 invalid).
+        let test_packet = test_packet.set(OPCODE_POS, &vec![3]);
+        let packet = &mut ReceivedPacket::new(test_packet.get()).into_parsable();
+        for _ in 0..2 {
+            auditor.audit(packet);
+        }
+        auditor.collect_metrics();
+
+        assert_eq!(
+            5,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<i64>(METRIC_OPCODE_BOOT_REQUESTS_COUNT)
+        );
+
+        assert_eq!(
+            3,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<i64>(METRIC_OPCODE_BOOT_REPLIES_COUNT)
+        );
+
+        assert_eq!(
+            2,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<i64>(METRIC_OPCODE_INVALID_COUNT)
+        );
+
+        assert_eq!(
+            50.0,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_BOOT_REQUESTS_PERCENT)
+        );
+
+        assert_eq!(
+            30.0,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_BOOT_REPLIES_PERCENT)
+        );
+
+        assert_eq!(
+            20.0,
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_INVALID_PERCENT)
+        );
+    }
+
+    #[test]
+    fn opcode_stream_auditor_profiles() {
+        assert!(OpCodeStreamAuditor::has_audit_profile(
+            &AuditProfile::LiveStreamFull
+        ));
+        assert!(OpCodeStreamAuditor::has_audit_profile(
+            &AuditProfile::PcapStreamFull
+        ));
+        assert!(!OpCodeStreamAuditor::has_audit_profile(
+            &AuditProfile::PcapFinalFull
+        ));
+    }
+
+    #[test]
+    fn opcode_stream_auditor_audit() {
+        let metrics_store = MetricsStore::new().to_shared();
+        let mut auditor = OpCodeStreamAuditor::from_metrics_store(&metrics_store);
         let test_packet = TestBootpPacket::new();
         let test_packet = test_packet.set(OPCODE_POS, &vec![1]);
         let packet = &mut ReceivedPacket::new(test_packet.get()).into_parsable();
@@ -190,72 +479,28 @@ mod tests {
         auditor.collect_metrics();
         let metrics_store_ref = metrics_store.clone();
 
-        let opcode_boot_requests_count = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_BOOT_REQUESTS_COUNT);
-        assert!(opcode_boot_requests_count.is_some());
-        assert_eq!(
-            5,
-            opcode_boot_requests_count
-                .unwrap()
-                .get_value_unwrapped::<i64>()
-        );
-
-        let opcode_boot_replies_count = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_BOOT_REPLIES_COUNT);
-        assert!(opcode_boot_replies_count.is_some());
-        assert_eq!(
-            0,
-            opcode_boot_replies_count
-                .unwrap()
-                .get_value_unwrapped::<i64>()
-        );
-
-        let opcode_invalid_count = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_INVALID_COUNT);
-        assert!(opcode_invalid_count.is_some());
-        assert_eq!(
-            0,
-            opcode_invalid_count.unwrap().get_value_unwrapped::<i64>()
-        );
-
-        let opcode_boot_requests_percent = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_BOOT_REQUESTS_PERCENT);
-        assert!(opcode_boot_requests_percent.is_some());
         assert_eq!(
             100.0,
-            opcode_boot_requests_percent
+            metrics_store_ref
+                .read()
                 .unwrap()
-                .get_value_unwrapped::<f64>()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_BOOT_REQUESTS_PERCENT_100)
         );
 
-        let opcode_boot_replies_percent = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_BOOT_REPLIES_PERCENT);
-        assert!(opcode_boot_replies_percent.is_some());
         assert_eq!(
             0.0,
-            opcode_boot_replies_percent
+            metrics_store_ref
+                .read()
                 .unwrap()
-                .get_value_unwrapped::<f64>()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_BOOT_REPLIES_PERCENT_100)
         );
 
-        let opcode_invalid_percent = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_INVALID_PERCENT);
-        assert!(opcode_invalid_percent.is_some());
         assert_eq!(
             0.0,
-            opcode_invalid_percent.unwrap().get_value_unwrapped::<f64>()
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_INVALID_PERCENT_100)
         );
 
         // Audit 3 reply packets. Now we have 8 packets audited (62.5% are requests and 37.5%
@@ -267,72 +512,28 @@ mod tests {
         }
         auditor.collect_metrics();
 
-        let opcode_boot_requests_count = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_BOOT_REQUESTS_COUNT);
-        assert!(opcode_boot_requests_count.is_some());
-        assert_eq!(
-            5,
-            opcode_boot_requests_count
-                .unwrap()
-                .get_value_unwrapped::<i64>()
-        );
-
-        let opcode_boot_replies_count = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_BOOT_REPLIES_COUNT);
-        assert!(opcode_boot_replies_count.is_some());
-        assert_eq!(
-            3,
-            opcode_boot_replies_count
-                .unwrap()
-                .get_value_unwrapped::<i64>()
-        );
-
-        let opcode_invalid_count = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_INVALID_COUNT);
-        assert!(opcode_invalid_count.is_some());
-        assert_eq!(
-            0,
-            opcode_invalid_count.unwrap().get_value_unwrapped::<i64>()
-        );
-
-        let opcode_boot_requests_percent = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_BOOT_REQUESTS_PERCENT);
-        assert!(opcode_boot_requests_percent.is_some());
         assert_eq!(
             62.5,
-            opcode_boot_requests_percent
+            metrics_store_ref
+                .read()
                 .unwrap()
-                .get_value_unwrapped::<f64>()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_BOOT_REQUESTS_PERCENT_100)
         );
 
-        let opcode_boot_replies_percent = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_BOOT_REPLIES_PERCENT);
-        assert!(opcode_boot_replies_percent.is_some());
         assert_eq!(
             37.5,
-            opcode_boot_replies_percent
+            metrics_store_ref
+                .read()
                 .unwrap()
-                .get_value_unwrapped::<f64>()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_BOOT_REPLIES_PERCENT_100)
         );
 
-        let opcode_invalid_percent = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_INVALID_PERCENT);
-        assert!(opcode_invalid_percent.is_some());
         assert_eq!(
             0.0,
-            opcode_invalid_percent.unwrap().get_value_unwrapped::<f64>()
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_INVALID_PERCENT_100)
         );
 
         // Finally, let's add some 2 invalid packets with opcode 3. We have a total of 10 packets
@@ -344,72 +545,28 @@ mod tests {
         }
         auditor.collect_metrics();
 
-        let opcode_boot_requests_count = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_BOOT_REQUESTS_COUNT);
-        assert!(opcode_boot_requests_count.is_some());
-        assert_eq!(
-            5,
-            opcode_boot_requests_count
-                .unwrap()
-                .get_value_unwrapped::<i64>()
-        );
-
-        let opcode_boot_replies_count = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_BOOT_REPLIES_COUNT);
-        assert!(opcode_boot_replies_count.is_some());
-        assert_eq!(
-            3,
-            opcode_boot_replies_count
-                .unwrap()
-                .get_value_unwrapped::<i64>()
-        );
-
-        let opcode_invalid_count = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_INVALID_COUNT);
-        assert!(opcode_invalid_count.is_some());
-        assert_eq!(
-            2,
-            opcode_invalid_count.unwrap().get_value_unwrapped::<i64>()
-        );
-
-        let opcode_boot_requests_percent = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_BOOT_REQUESTS_PERCENT);
-        assert!(opcode_boot_requests_percent.is_some());
         assert_eq!(
             50.0,
-            opcode_boot_requests_percent
+            metrics_store_ref
+                .read()
                 .unwrap()
-                .get_value_unwrapped::<f64>()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_BOOT_REQUESTS_PERCENT_100)
         );
 
-        let opcode_boot_replies_percent = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_BOOT_REPLIES_PERCENT);
-        assert!(opcode_boot_replies_percent.is_some());
         assert_eq!(
             30.0,
-            opcode_boot_replies_percent
+            metrics_store_ref
+                .read()
                 .unwrap()
-                .get_value_unwrapped::<f64>()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_BOOT_REPLIES_PERCENT_100)
         );
 
-        let opcode_invalid_percent = metrics_store_ref
-            .read()
-            .unwrap()
-            .get(METRIC_OPCODE_INVALID_PERCENT);
-        assert!(opcode_invalid_percent.is_some());
         assert_eq!(
             20.0,
-            opcode_invalid_percent.unwrap().get_value_unwrapped::<f64>()
+            metrics_store_ref
+                .read()
+                .unwrap()
+                .get_metric_value_unwrapped::<f64>(METRIC_OPCODE_INVALID_PERCENT_100)
         );
     }
 }

--- a/src/auditor/util.rs
+++ b/src/auditor/util.rs
@@ -8,25 +8,26 @@ use simple_moving_average::{NoSumSMA, SMA};
 ///
 /// # Generic Parameters
 ///
-/// - `IDENT` - a unique rank identifier. It typically associates the rank
+/// - `Indent` - a unique rank identifier. It typically associates the rank
 ///   with a client (e.g., MAC address).
-/// - `SCORE` - a score that can be compared with other ranks. It is a metric
+/// - `Score` - a score that can be compared with other ranks. It is a metric
 ///   associated with  a client (e.g., `secs` field value).
+///
 #[derive(Debug)]
-pub struct MovingRank<IDENT, SCORE>
+pub struct MovingRank<Indent, Score>
 where
-    SCORE: std::cmp::PartialOrd,
+    Score: std::cmp::PartialOrd,
 {
     /// A rank identifier.
     ///
     /// Typically a string value, such as client MAC address.
-    pub id: IDENT,
+    pub id: Indent,
 
     /// A metric used for scoring.
     ///
     /// Typically a number that can be compared with other numbers (ranks).
     /// The higher number is scored as a higher rank.
-    pub score: SCORE,
+    pub score: Score,
 
     /// Score age.
     ///
@@ -37,10 +38,10 @@ where
     pub age: usize,
 }
 
-impl<IDENT, SCORE> MovingRank<IDENT, SCORE>
+impl<Indent, Score> MovingRank<Indent, Score>
 where
-    IDENT: std::cmp::PartialEq,
-    SCORE: std::cmp::PartialOrd,
+    Indent: std::cmp::PartialEq,
+    Score: std::cmp::PartialOrd,
 {
     /// Instantiates a new rank with an age of 0.
     ///
@@ -48,7 +49,7 @@ where
     ///
     /// - `id` - rank identifier.
     /// - `score` - score to be ranked.
-    pub fn new(id: IDENT, score: SCORE) -> MovingRank<IDENT, SCORE> {
+    pub fn new(id: Indent, score: Score) -> MovingRank<Indent, Score> {
         MovingRank { id, score, age: 0 }
     }
 }
@@ -57,9 +58,9 @@ where
 ///
 /// # Generic Parameters
 ///
-/// - `IDENT` - a unique rank identifier. It typically associates the rank
+/// - `Indent` - a unique rank identifier. It typically associates the rank
 ///   with a client (e.g., MAC address).
-/// - `SCORE` - a score that can be compared with other ranks. It is a metric
+/// - `Score` - a score that can be compared with other ranks. It is a metric
 ///   associated with  a client (e.g., `secs` field value).
 /// - `RANKS_NUM` - maximum number of the top ranks.
 /// - `WINDOW_SIZE` - maximum age of the ranks until they expire.
@@ -83,29 +84,30 @@ where
 /// scored value. In this case the `secs` field is the two byte unsigned integer.
 /// Finally, the `String` is the identifier type. Here, we represent the client
 /// MAC address as a string.
+///
 #[derive(Debug)]
-pub struct MovingRanks<IDENT, SCORE, const RANKS_NUM: usize, const WINDOW_SIZE: usize>
+pub struct MovingRanks<Indent, Score, const RANKS_NUM: usize, const WINDOW_SIZE: usize>
 where
-    IDENT: std::cmp::PartialEq,
-    SCORE: std::cmp::PartialOrd,
+    Indent: std::cmp::PartialEq,
+    Score: std::cmp::PartialOrd,
 {
     /// Stored ranks.
     ///
     /// This vector has a length between 0 and `RANKS_NUM`. The ranks can be
     /// retrieved using the [`MovingRanks::get_rank`] function.
-    ranks: Vec<MovingRank<IDENT, SCORE>>,
+    ranks: Vec<MovingRank<Indent, Score>>,
 }
 
-impl<IDENT, SCORE, const RANKS_NUM: usize, const WINDOW_SIZE: usize>
-    MovingRanks<IDENT, SCORE, RANKS_NUM, WINDOW_SIZE>
+impl<Indent, Score, const RANKS_NUM: usize, const WINDOW_SIZE: usize>
+    MovingRanks<Indent, Score, RANKS_NUM, WINDOW_SIZE>
 where
-    IDENT: std::cmp::PartialEq,
-    SCORE: std::cmp::PartialOrd,
+    Indent: std::cmp::PartialEq,
+    Score: std::cmp::PartialOrd,
 {
     /// Instantiates the [`MovingRanks`].
     ///
     /// It creates an empty set of ranks.
-    pub fn new() -> MovingRanks<IDENT, SCORE, RANKS_NUM, WINDOW_SIZE> {
+    pub fn new() -> MovingRanks<Indent, Score, RANKS_NUM, WINDOW_SIZE> {
         MovingRanks { ranks: Vec::new() }
     }
 
@@ -121,7 +123,8 @@ where
     ///
     /// - `id` - a rank identifier (e.g., a client MAC address).
     /// - `score` - a value of the metrics (e.g., `secs` field value).
-    pub fn add_score(&mut self, id: IDENT, score: SCORE) {
+    ///
+    pub fn add_score(&mut self, id: Indent, score: Score) {
         // Remove expired scores.
         self.ranks
             .retain(|rank| rank.age < WINDOW_SIZE && rank.id != id);
@@ -165,8 +168,89 @@ where
     /// If the specified index is greater than the number of ranks this function
     /// returns `None`. Otherwise, it returns a specified rank where `0` means the
     /// highest rank.
-    pub fn get_rank(&self, index: usize) -> Option<&MovingRank<IDENT, SCORE>> {
+    ///
+    pub fn get_rank(&self, index: usize) -> Option<&MovingRank<Indent, Score>> {
         self.ranks.get(index)
+    }
+}
+
+/// Collection of related counters with calculable percentages for each
+/// counter.
+///
+/// A typical application of the [`TotalCounter`] is when an auditor counts
+/// several types of the processed messages and needs to calculate occurence
+/// percentage of each message type among all messages.
+///
+/// # Generic Parameters
+///
+/// - `COUNTERS_NUM` - a number of different `u64` counters.
+///
+/// # Usage Example
+///
+/// Suppose you want to track the occurence of 3 message types. The [`TotalCounter`]
+/// can be used as follows to display the percentages for each counter:
+///
+/// ```rust
+/// let mut totals = TotalCounter::<3>::new();
+/// totals.increase(0);
+/// totals.increase(1);
+/// println!("{}", totals.percentage(0)); // should print 50.0
+/// println!("{}", totals.percentage(1)); // should print 50.0
+/// println!("{}", totals.percentage(2)); // should print 0.0
+/// ```
+///
+/// It is also possible to get the absolute values using the [`TotalCounter::counter`]
+/// function.
+///
+#[derive(Clone, Debug)]
+pub struct TotalCounter<const COUNTERS_NUM: usize> {
+    counters: [i64; COUNTERS_NUM],
+}
+
+impl<const METRICS_NUM: usize> TotalCounter<METRICS_NUM> {
+    /// Instantiates the counters.
+    pub fn new() -> Self {
+        TotalCounter {
+            counters: [0; METRICS_NUM],
+        }
+    }
+
+    /// Increases a selected counter by `1`.
+    ///
+    /// # Errors
+    ///
+    /// This function will panic if the `metric_index` is out of bounds.
+    ///
+    pub fn increase(&mut self, metric_index: usize) {
+        // Add a sample of `1` to a selected metric.
+        self.counters[metric_index] += 1;
+    }
+
+    /// Returns the current value for a selected counter.
+    ///
+    /// # Errors
+    ///
+    /// This function will panic if the `metric_index` is out of bounds.
+    ///
+    pub fn counter(&self, metric_index: usize) -> i64 {
+        self.counters[metric_index]
+    }
+
+    /// Returns the percentage of the selected metrics value among all values.
+    ///
+    /// # Errors
+    ///
+    /// This function will panic if the `metric_index` is out of bounds.
+    ///
+    pub fn percentage(&self, metric_index: usize) -> f64 {
+        let mut sum: i64 = 0;
+        for i in 0..METRICS_NUM {
+            sum += self.counters[i];
+        }
+        match sum {
+            0 => 0.0,
+            sum => (1000 * self.counters[metric_index] / sum) as f64 / 10f64,
+        }
     }
 }
 
@@ -280,11 +364,58 @@ impl<const PRECISION: usize, const WINDOW_SIZE: usize> RoundedSMA<PRECISION, WIN
     }
 }
 
+/// A total average implementation with an arbitrary precision.
+///
+/// It has the same interface as the [`RoundedSMA`] but it calculates an
+/// average value from all samples rather than from a moving window of
+/// samples. It uses less memory than [`RoundedSMA`] because it doesn't need
+/// to retain the samples. It only retains the total value and the number
+/// of samples.
+///
+/// # Generic Parameters
+///
+/// - PRECISION - selected precision (i.e., 10 for single decimal, 100 for two decimals
+///   1000 for three, etc.)
+///
+#[derive(Debug)]
+pub struct RoundedSTA<const PRECISION: usize> {
+    sum: u64,
+    samples_num: u64,
+}
+
+impl<const PRECISION: usize> RoundedSTA<PRECISION> {
+    /// Instantiates the [`RoundedSMA`].
+    pub fn new() -> RoundedSTA<PRECISION> {
+        RoundedSTA {
+            sum: 0,
+            samples_num: 0,
+        }
+    }
+
+    /// Adds a sample.
+    ///
+    /// # Parameters
+    ///
+    /// - sample - a sample value.
+    pub fn add_sample(&mut self, sample: u64) {
+        self.sum += PRECISION as u64 * sample;
+        self.samples_num += 1;
+    }
+
+    /// Returns an average with a selected precision.
+    pub fn average(&self) -> f64 {
+        match self.samples_num {
+            0 => 0.0,
+            _ => (self.sum / self.samples_num) as f64 / PRECISION as f64,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::auditor::util::RoundedSMA;
+    use crate::auditor::util::{RoundedSMA, RoundedSTA};
 
-    use super::MovingRanks;
+    use super::{MovingRanks, TotalCounter};
 
     /// A convenience function testing the returned rank.
     fn expect_rank(
@@ -349,6 +480,36 @@ mod tests {
     }
 
     #[test]
+    fn total_counter_zero() {
+        let totals = TotalCounter::<3>::new();
+        assert_eq!(0.0, totals.percentage(0));
+        assert_eq!(0.0, totals.percentage(1));
+        assert_eq!(0.0, totals.percentage(2));
+
+        assert_eq!(0, totals.counter(0));
+        assert_eq!(0, totals.counter(1));
+        assert_eq!(0, totals.counter(2));
+    }
+
+    #[test]
+    fn total_counter() {
+        let mut totals = TotalCounter::<3>::new();
+        for _ in 0..3 {
+            totals.increase(0);
+        }
+        for _ in 0..4 {
+            totals.increase(1);
+        }
+        assert_eq!(42.8, totals.percentage(0));
+        assert_eq!(57.1, totals.percentage(1));
+        assert_eq!(0.0, totals.percentage(2));
+
+        assert_eq!(3, totals.counter(0));
+        assert_eq!(4, totals.counter(1));
+        assert_eq!(0, totals.counter(2));
+    }
+
+    #[test]
     fn rounded_sma_prec10() {
         let mut avg = RoundedSMA::<10, 100>::new();
         avg.add_sample(1);
@@ -389,5 +550,31 @@ mod tests {
         assert_eq!(0.5, avg.average());
         avg.add_sample(0);
         assert_eq!(0.0, avg.average());
+    }
+
+    #[test]
+    fn rounded_sta_prec10() {
+        let mut avg = RoundedSTA::<10>::new();
+        avg.add_sample(1);
+        assert_eq!(1.0, avg.average());
+        avg.add_sample(1);
+        assert_eq!(1.0, avg.average());
+        avg.add_sample(2);
+        assert_eq!(1.3, avg.average());
+        avg.add_sample(8);
+        assert_eq!(3.0, avg.average());
+    }
+
+    #[test]
+    fn rounded_sta_prec100() {
+        let mut avg = RoundedSTA::<100>::new();
+        avg.add_sample(1);
+        assert_eq!(1.0, avg.average());
+        avg.add_sample(0);
+        assert_eq!(0.5, avg.average());
+        avg.add_sample(1);
+        assert_eq!(0.66, avg.average());
+        avg.add_sample(8);
+        assert_eq!(2.5, avg.average());
     }
 }


### PR DESCRIPTION
Split the existing auditors into the ones that can be run for live captures or pcap streams and the pcap analysis with final metrics. 